### PR TITLE
cap git_clone_url version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       aws-sdk (~> 2)
       bintray_deploy
       git
-      git_clone_url
+      git_clone_url (~> 1.0)
       net-scp
       thor
 
@@ -81,8 +81,8 @@ GEM
       libyajl2 (~> 1.2)
     formatador (0.2.5)
     git (1.2.9.1)
-    git_clone_url (0.1.0)
-      uri-ssh_git
+    git_clone_url (1.0.1)
+      uri-ssh_git (>= 1.0, < 2.0)
     guard (2.12.9)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -244,7 +244,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
-    uri-ssh_git (0.1.1)
+    uri-ssh_git (1.0.0)
     uuidtools (2.1.5)
     wmi-lite (1.0.0)
     yajl-ruby (1.2.1)

--- a/opskeleton.gemspec
+++ b/opskeleton.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('aws-sdk', '~> 2')
   gem.add_dependency('net-scp')
   gem.add_dependency('git')
-  gem.add_dependency('git_clone_url')
+  gem.add_dependency('git_clone_url', '~> 1.0')
   gem.add_development_dependency('puppet','=3.7.5')
   gem.add_development_dependency('chef')
   gem.add_development_dependency('rspec-puppet')


### PR DESCRIPTION
`git_clone_url` will have breaking change.
This will break `opskeleton` behavior, so I
recommend `git_clone_url` v1.x.
see:
https://github.com/packsaddle/ruby-git_clone_url/issues/6
